### PR TITLE
Add option to reverse animation direction

### DIFF
--- a/src/javascript/app/components/Overlays/VideoParamsForm/component.jsx
+++ b/src/javascript/app/components/Overlays/VideoParamsForm/component.jsx
@@ -22,6 +22,7 @@ const VideoParamsForm = (props) => {
   const [palette, setPalette] = useState(props.palette);
   const [invertPalette, setInvertPalette] = useState(props.invertPalette);
   const [yoyo, setYoyo] = useState(props.yoyo);
+  const [reverse, setReverse] = useState(props.reverse);
   const [frame, setFrame] = useState(props.frame);
   const [lockFrame, setLockFrame] = useState(props.lockFrame);
   const [exportFrameMode, setExportFrameMode] = useState(props.exportFrameMode);
@@ -33,13 +34,14 @@ const VideoParamsForm = (props) => {
       palette,
       invertPalette,
       yoyo,
+      reverse,
       frame,
       lockFrame,
       exportFrameMode,
     };
 
     update(cleanState);
-  }, [frameRate, scaleFactor, palette, invertPalette, yoyo, frame, lockFrame, exportFrameMode, update]);
+  }, [frameRate, scaleFactor, palette, invertPalette, yoyo, reverse, frame, lockFrame, exportFrameMode, update]);
 
   if (!imageCount) {
     return null;
@@ -88,6 +90,25 @@ const VideoParamsForm = (props) => {
         />
         <SVG name="checkmark" />
         <span className="video-params__check-label-text">Yoyo-Effect</span>
+      </label>
+      <label
+        className={
+          classnames('video-params__check-label', {
+            'video-params__check-label--checked': reverse,
+          })
+        }
+        title="Reverse animation direction"
+      >
+        <input
+          type="checkbox"
+          className="video-params__checkbox"
+          checked={reverse}
+          onChange={(ev) => {
+            setReverse(ev.target.checked);
+          }}
+        />
+        <SVG name="checkmark" />
+        <span className="video-params__check-label-text">Reverse Direction</span>
       </label>
       <div className="video-params__select-label">
         Palette
@@ -144,6 +165,7 @@ VideoParamsForm.propTypes = {
   palette: PropTypes.string.isRequired,
   invertPalette: PropTypes.bool.isRequired,
   yoyo: PropTypes.bool.isRequired,
+  reverse: PropTypes.bool.isRequired,
   lockFrame: PropTypes.bool.isRequired,
   exportFrameMode: PropTypes.string.isRequired,
   frame: PropTypes.string.isRequired,

--- a/src/javascript/app/components/Overlays/VideoParamsForm/container.js
+++ b/src/javascript/app/components/Overlays/VideoParamsForm/container.js
@@ -6,6 +6,7 @@ const mapStateToProps = (state) => ({
   scaleFactor: state.videoParams.scaleFactor || [...state.exportScaleFactors].pop() || 4,
   frameRate: state.videoParams.frameRate || 12,
   yoyo: state.videoParams.yoyo || false,
+  reverse: state.videoParams.reverse || false,
   lockFrame: state.videoParams.lockFrame || false,
   invertPalette: state.videoParams.invertPalette || false,
   frame: state.videoParams.frame || '',

--- a/src/javascript/app/components/Overlays/VideoParamsForm/index.scss
+++ b/src/javascript/app/components/Overlays/VideoParamsForm/index.scss
@@ -25,6 +25,7 @@
       width: 30px;
       height: 30px;
       margin-right: 10px;
+      fill: currentColor;
     }
 
     .tick {

--- a/src/javascript/app/store/defaults.js
+++ b/src/javascript/app/store/defaults.js
@@ -75,7 +75,7 @@ const definitions = [
     value: null,
   },
   {
-    // how to save videos (loop, crop, yoyo, palette)
+    // how to save videos (loop, crop, yoyo, reverse, palette)
     key: 'videoParams',
     saveLocally: true,
     saveExport: ['settings', 'remote'],

--- a/src/javascript/app/store/middlewares/animate.js
+++ b/src/javascript/app/store/middlewares/animate.js
@@ -63,6 +63,7 @@ const animate = (store) => (next) => (action) => {
       frameRate,
       imageSelection,
       yoyo,
+      reverse,
       frame: videoFrame,
       lockFrame: videoLockFrame,
       invertPalette: videoInvertPalette,
@@ -128,6 +129,10 @@ const animate = (store) => (next) => (action) => {
           reverseImages.pop();
 
           allImages.push(...reverseImages);
+        }
+
+        if (reverse) {
+          allImages.reverse();
         }
 
         const addImages = getAddImages(store.dispatch, gifWriter, queue, frameRate, allImages.length);


### PR DESCRIPTION
- Adds option to reverse animation direction, useful when range selecting a large number of photos in a sequence that were added in reverse order (ie from picnrec)
- Fixes issue with the Yoyo checkbox not changing color for dark them

![reverse](https://user-images.githubusercontent.com/9136454/171761801-1fb3a0ff-f35a-40a6-8cc7-2287f02f2a21.png)